### PR TITLE
PDOK-14076 Minio fixes

### DIFF
--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -1,7 +1,7 @@
 base-resource: https://example.org/catalog/1.0/
 default: night
 additional-formats:
-  application/json+custom_style: custom_style
+  application/vnd.custom.style+json: custom
 styles:
   - id: "night"
     title: "Topographic night style"
@@ -41,7 +41,7 @@ styles:
         asset-filename: "custom.style"
         href: "https://example.org/catalog/1.0/styles/night?f=custom_style"
         rel: "stylesheet"
-        type: "application/json+custom_style"
+        type: "application/vnd.custom.style+json"
     layers:
     - id: "VegetationSrf"
       type: "polygons"

--- a/main.go
+++ b/main.go
@@ -94,7 +94,7 @@ func generate(ctx *util.Context) error {
 		if document.Error != nil { // TODO: not sure about this pattern, perhaps just implement Fatal logging; think about: https://stackoverflow.com/a/33890104
 			return err
 		}
-		err := ctx.Writer.Write(document.Path, document.Content, document.MediaType, config.AdditionalFormats)
+		err := ctx.Writer.Write(document.Path, document.Content, document.MediaType)
 		if err != nil {
 			return err
 		}

--- a/pkg/generate_test.go
+++ b/pkg/generate_test.go
@@ -37,25 +37,25 @@ func TestGenerateDocuments(t *testing.T) {
 			bytes.NewBuffer([]byte("")),
 			nil},
 		{
-			"styles/night",
+			"styles/night.mapbox",
 			"application/vnd.mapbox.style+json",
 			bytes.NewBuffer([]byte( //language=json
 				`{"MAPBOX_STYLE": "https://example.org/catalog/1.0"}`)),
 			nil},
 		{
-			"styles/night",
+			"styles/night.sld",
 			"application/vnd.ogc.sld+xml;version=1.0",
 			bytes.NewBuffer([]byte( //language=xml
 				`<root href="https://example.org/catalog/1.0">SLD</root>`)),
 			nil},
 		{
-			"styles/night",
-			"application/json+custom_style",
+			"styles/night.custom",
+			"application/vnd.custom.style+json",
 			bytes.NewBuffer([]byte( //language=text
 				`Custom Style = https://example.org/catalog/1.0`)),
 			nil},
 		{
-			"styles/night/metadata",
+			"styles/night/metadata.json",
 			"application/json",
 			bytes.NewBuffer([]byte( //language=json
 				`{
@@ -100,9 +100,9 @@ func TestGenerateDocuments(t *testing.T) {
 					  "title": "Custom Style",
 					  "native": true,
 					  "link": {
-						"href": "https://example.org/catalog/1.0/styles/night?f=custom_style",
+						"href": "https://example.org/catalog/1.0/styles/night?f=custom",
 						"rel": "stylesheet",
-						"type": "application/json+custom_style"
+						"type": "application/vnd.custom.style+json"
 					  }
 					}
 				  ],
@@ -143,7 +143,7 @@ func TestGenerateDocuments(t *testing.T) {
 			),
 			nil},
 		{
-			"styles",
+			"styles.json",
 			"application/json",
 			bytes.NewBuffer([]byte( //language=json
 				`{
@@ -175,9 +175,9 @@ func TestGenerateDocuments(t *testing.T) {
 						  "type": "application/vnd.ogc.sld+xml;version=1.0"
 						},
 						{	
-						  "href": "https://example.org/catalog/1.0/styles/night?f=custom_style",
+						  "href": "https://example.org/catalog/1.0/styles/night?f=custom",
 						  "rel": "stylesheet",
-						  "type": "application/json+custom_style"
+						  "type": "application/vnd.custom.style+json"
 						}
 					  ]
 					}
@@ -199,7 +199,7 @@ func TestGenerateDocumentsMinimalConfig(t *testing.T) {
 	documents := GenerateDocuments(config, "../examples/assets", []models.Format{models.JsonFormat})
 	expectedDocuments := []models.Document{
 		{
-			"styles/night/metadata",
+			"styles/night/metadata.json",
 			"application/json",
 			bytes.NewBuffer([]byte( //language=json
 				`{
@@ -215,7 +215,7 @@ func TestGenerateDocumentsMinimalConfig(t *testing.T) {
 				}`)),
 			nil},
 		{
-			"styles",
+			"styles.json",
 			"application/json",
 			bytes.NewBuffer([]byte( //language=json
 				`{

--- a/pkg/models/styles.go
+++ b/pkg/models/styles.go
@@ -62,6 +62,18 @@ func (link Link) WithOtherRelation(otherRelation LinkRelation) *Link {
 	return &link
 }
 
+func (link Link) ToPath(identifier string, additionalFormats map[MediaType]Format) (string, error) {
+	path, err := link.Rel.ToPath(identifier)
+	if err != nil {
+		return "", err
+	}
+	extension := link.Type.ToFormat(additionalFormats, false)
+	if extension != "" {
+		path = fmt.Sprintf("%s.%s", path, extension)
+	}
+	return path, nil
+}
+
 func (link *Link) UpdateHref(baseResource string, styleId string, additionalFormats map[MediaType]Format) error {
 	url, err := link.Rel.ToUrl(baseResource, styleId)
 	if err != nil {

--- a/pkg/render.go
+++ b/pkg/render.go
@@ -5,11 +5,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/pdok/goas/pkg/models"
+	"strings"
 )
 
 type Renderer func(obj interface{}, path string) (*models.Document, error)
 
 func Render(obj interface{}, path string, format models.Format) (*models.Document, error) {
+	if !strings.HasSuffix(path, string(format)) {
+		path = fmt.Sprintf("%s.%s", path, format)
+	}
 	renderer, err := getRenderer(format)
 	if err != nil {
 		return nil, err

--- a/pkg/render_test.go
+++ b/pkg/render_test.go
@@ -16,7 +16,7 @@ type NestedTestStruct struct {
 
 func TestRenderJson(t *testing.T) {
 	obj := TestStruct{NestedTestStruct{"test"}}
-	path := "."
+	path := "test.json"
 	expected := "{\"nested\":{\"test\":\"test\"}}\n"
 
 	result, err := Render(obj, path, models.JsonFormat)

--- a/util/context.go
+++ b/util/context.go
@@ -19,7 +19,7 @@ var DefaultFormats = []models.Format{models.JsonFormat}
 func CreateContext(c *cli.Context) (*Context, error) {
 	s3Endpoint := c.String("s3-endpoint")
 	s3AccessKey := c.String("s3-access-key")
-	s3SecretKey := c.String("s3-secret-key")
+	s3SecretKey := c.String("s3-secret")
 	s3Bucket := c.String("s3-bucket")
 	s3Prefix := c.String("s3-prefix")
 	fileDestination := c.String("file-destination")


### PR DESCRIPTION
Write files with extensions to minio to prevent clashes between files with the same extension.

# Omschrijving

Een omschrijving van wat je hebt toegevoegd/veranderd:

https://dev.kadaster.nl/jira/browse/PDOK-14076

Blijft wel een vervelende bijkomstigheid dat de file-extensie nu mapbox is ipv json. Eigenlijk moet dat nog gefixt. Er zijn een aantal mogelijke oplossingen. Zonder meer voor json kiezen zorgt nog steeds voor clashes. Overigens is bij verschillende sld versies ook een probleem (maar: only the latest & greatest). 

Als je het netjes wilt doen ontkom je er ben ik bang niet aan om ook nog een file-extensie per `Format` vast te leggen. 

## Type verandering

(Verwijder de opties die niet relevant zijn.)

- Verbetering oude feature
- Bugfix
- Refactor
- Aanpassing van de configuratie

# Checklist:

- [X] Ik heb de code in deze PR zelf nogmaals nagekeken
- [X] Ik heb mijn code beter achtergelaten dan dat ik het aantrof
- [ ] De code is leesbaar en de moeilijke onderdelen zijn voorzien van commentaar
- [ ] Ik heb de tests toegevoegd/uitgebreid indien nodig
- [X] Ik heb de tests gedraaid die de werking van mijn wijziging bewijst
- [ ] De [PDOK documentatie](https://github.com/PDOK/interne-documentatie) is bijgewerkt indien nodig.
- [ ] Er zit geen gevoelig informatie in deze PR (wachtwoorden etc)