### PR TITLE
Add extension name to style.

### DIFF
--- a/pkg/generate_test.go
+++ b/pkg/generate_test.go
@@ -37,7 +37,7 @@ func TestGenerateDocuments(t *testing.T) {
 			bytes.NewBuffer([]byte("")),
 			nil},
 		{
-			"styles/night.mapbox",
+			"styles/night.mapbox.json",
 			"application/vnd.mapbox.style+json",
 			bytes.NewBuffer([]byte( //language=json
 				`{"MAPBOX_STYLE": "https://example.org/catalog/1.0"}`)),
@@ -81,7 +81,7 @@ func TestGenerateDocuments(t *testing.T) {
 					  "specification": "https://docs.mapbox.com/mapbox-gl-js/style-spec/",
 					  "native": true,
 					  "link": {
-						"href": "https://example.org/catalog/1.0/styles/night?f=mapbox",
+						"href": "https://example.org/catalog/1.0/styles/night?f=mapbox.json",
 						"rel": "stylesheet",
 						"type": "application/vnd.mapbox.style+json"
 					  }
@@ -165,7 +165,7 @@ func TestGenerateDocuments(t *testing.T) {
 						  "title": "Style Metadata for night"
 						},
 						{
-						  "href": "https://example.org/catalog/1.0/styles/night?f=mapbox",
+						  "href": "https://example.org/catalog/1.0/styles/night?f=mapbox.json",
 						  "rel": "stylesheet",
 						  "type": "application/vnd.mapbox.style+json"
 						},

--- a/pkg/models/enums.go
+++ b/pkg/models/enums.go
@@ -112,7 +112,7 @@ const (
 	JsonFormat   Format = "json"
 	HtmlFormat   Format = "html"
 	SldFormat    Format = "sld"
-	MapboxFormat Format = "mapbox"
+	MapboxFormat Format = "mapbox.json"
 
 	mediaTypeSeperator     = ";"
 	mediaTypePartSeperator = "="


### PR DESCRIPTION
# Omschrijving

Voorstel om tevens de extensie in het format op te nemen. Zie `pkg/generate_test.go` bij de files changed voor het effect.

Een alternatief is een extra mapping die naast format / mediaType ook nog de bestandsnaam bij wegschrijven vastlegd en dit op te nemen bij de additional-formats configuratie. 

Voorbeeld van die alternatieve oplossing:
`config.yaml`: 
```yaml
application/json+custom_style:
- name: custom_style
  filename: custom.style
```

https://dev.kadaster.nl/jira/browse/PDOK-14076

## Type verandering

(Verwijder de opties die niet relevant zijn.)
- Verbetering oude feature

# Checklist:

- [ ] Ik heb de code in deze PR zelf nogmaals nagekeken
- [ ] Ik heb mijn code beter achtergelaten dan dat ik het aantrof
- [ ] De code is leesbaar en de moeilijke onderdelen zijn voorzien van commentaar
- [ ] Ik heb de tests toegevoegd/uitgebreid indien nodig
- [ ] Ik heb de tests gedraaid die de werking van mijn wijziging bewijst
- [ ] De [PDOK documentatie](https://github.com/PDOK/interne-documentatie) is bijgewerkt indien nodig.
- [ ] Er zit geen gevoelig informatie in deze PR (wachtwoorden etc)