### PR TITLE
Make secure minio connection configurable.

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,6 +41,11 @@ func main() {
 			Usage:   "S3 prefix where the styles land on S3 (optional)",
 			EnvVars: []string{"S3_PREFIX"},
 		},
+		&cli.BoolFlag{
+			Name:    "s3-secure",
+			Usage:   "use a secure S3 connection [true, false], defaults to false (optional)",
+			EnvVars: []string{"S3_SECURE"},
+		},
 		&cli.StringFlag{
 			Name:    "file-destination",
 			Usage:   "Path where the styles land on disk (optional)",

--- a/util/context.go
+++ b/util/context.go
@@ -14,6 +14,7 @@ type S3Context struct {
 	SecretKey string
 	Bucket    string
 	Prefix    string
+	Secure    bool
 }
 
 type Context struct {
@@ -33,6 +34,7 @@ func CreateContext(c *cli.Context) (*Context, error) {
 	s3SecretKey := c.String("s3-secret")
 	s3Bucket := c.String("s3-bucket")
 	s3Prefix := c.String("s3-prefix")
+	s3Secure := c.Bool("s3-secure")
 	fileDestination := c.String("file-destination")
 
 	isLocal := fileDestination != ""
@@ -49,7 +51,7 @@ func CreateContext(c *cli.Context) (*Context, error) {
 		if !strings.HasSuffix(s3Prefix, "/") {
 			s3Prefix = s3Prefix + "/"
 		}
-		s3Context = S3Context{s3Endpoint, s3AccessKey, s3SecretKey, s3Bucket, s3Prefix}
+		s3Context = S3Context{s3Endpoint, s3AccessKey, s3SecretKey, s3Bucket, s3Prefix, s3Secure}
 	}
 
 	var assetDir, configPath string

--- a/util/writer.go
+++ b/util/writer.go
@@ -77,10 +77,10 @@ func (f FileWriter) Write(path string, buffer *bytes.Buffer, _ models.MediaType)
 	return nil
 }
 
-func newMinioWriter(s3Endpoint string, s3AccessKey string, s3SecretKey string, s3Bucket string, s3Prefix string) (Writer, error) {
+func newMinioWriter(s3Endpoint string, s3AccessKey string, s3SecretKey string, s3Bucket string, s3Prefix string, s3Secure bool) (Writer, error) {
 	minioClient, err := minio.New(s3Endpoint, &minio.Options{
 		Creds:  credentials.NewStaticV4(s3AccessKey, s3SecretKey, ""),
-		Secure: false,
+		Secure: s3Secure,
 	})
 	if err != nil {
 		return nil, err
@@ -97,7 +97,7 @@ func NewWriter(ctx *Context) (writer Writer, err error) {
 	if ctx.isLocal {
 		writer = &FileWriter{*ctx.FileDestination}
 	} else {
-		writer, err = newMinioWriter(ctx.S3.Endpoint, ctx.S3.AccessKey, ctx.S3.SecretKey, ctx.S3.Bucket, ctx.S3.Prefix)
+		writer, err = newMinioWriter(ctx.S3.Endpoint, ctx.S3.AccessKey, ctx.S3.SecretKey, ctx.S3.Bucket, ctx.S3.Prefix, ctx.S3.Secure)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
# Omschrijving

Een omschrijving van wat je hebt toegevoegd/veranderd:

The connection ssl setting was hardcoded `false`. this fixes that. 

## Type verandering

(Verwijder de opties die niet relevant zijn.)

- Aanpassing van de configuratie

# Checklist:

- [ ] Ik heb de code in deze PR zelf nogmaals nagekeken
- [ ] Ik heb mijn code beter achtergelaten dan dat ik het aantrof
- [ ] De code is leesbaar en de moeilijke onderdelen zijn voorzien van commentaar
- [ ] Ik heb de tests toegevoegd/uitgebreid indien nodig
- [X] Ik heb de tests gedraaid die de werking van mijn wijziging bewijst
- [ ] De [PDOK documentatie](https://github.com/PDOK/interne-documentatie) is bijgewerkt indien nodig.
- [ ] Er zit geen gevoelig informatie in deze PR (wachtwoorden etc)